### PR TITLE
Add Spring Boot to Resolver and Minter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Persistent ID Service
-![Build status](https://travis-ci.org/HawaiiStateDigitalArchives/PID-webservice.svg?branch=master)
+[![Build status](https://travis-ci.org/HawaiiStateDigitalArchives/PID-webservice.svg?branch=master)](https://travis-ci.org/HawaiiStateDigitalArchives/PID-webservice/)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Persistent ID Service
+![Build status](https://travis-ci.org/HawaiiStateDigitalArchives/PID-webservice.svg?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Persistent ID Service

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>gov.hawaii.digitalarchives</groupId>
+    <artifactId>pid-web-service</artifactId>
+    <name>PID Web Service</name>
+    <packaging>pom</packaging>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <url>http://digitalarchives.hawaii.gov</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+
+        <java.version>1.8</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>Minter</module>
+        <module>PURL</module>
+    </modules>
+</project>


### PR DESCRIPTION
Add Spring Boot to the projects so that they can be stand-alone applications. Aside from improving the quality of code, a number of features have been removed and replaced by Spring Boot's built-in libraries. 
